### PR TITLE
Exposes danger_id via EnvironmentManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## master
 
+* Exposes danger_id publicly via `EnvironmentManager`. Access it in the `Dangerfile` via `danger.env.danger_id` [@rpassis](https://github.com/rpassis/)
+
 ## 6.0.10
 
 * Integrated build status Bitbucket Server REST API

--- a/lib/danger/danger_core/environment_manager.rb
+++ b/lib/danger/danger_core/environment_manager.rb
@@ -3,7 +3,7 @@ require "danger/request_sources/request_source"
 
 module Danger
   class EnvironmentManager
-    attr_accessor :ci_source, :request_source, :scm, :ui
+    attr_accessor :ci_source, :request_source, :scm, :ui, :danger_id
 
     # Finds a Danger::CI class based on the ENV
     def self.local_ci_source(env)
@@ -25,10 +25,11 @@ module Danger
       "danger_base".freeze
     end
 
-    def initialize(env, ui = nil)
+    def initialize(env, ui = nil, danger_id = "danger")
       ci_klass = self.class.local_ci_source(env)
       self.ci_source = ci_klass.new(env)
       self.ui = ui || Cork::Board.new(silent: false, verbose: false)
+      self.danger_id = danger_id
 
       RequestSources::RequestSource.available_request_sources.each do |klass|
         next unless self.ci_source.supports?(klass)

--- a/lib/danger/danger_core/executor.rb
+++ b/lib/danger/danger_core/executor.rb
@@ -22,7 +22,7 @@ module Danger
       validate!(cork, fail_if_no_pr: fail_if_no_pr)
 
       # OK, we now know that Danger can run in this enviroment
-      env ||= EnvironmentManager.new(system_env, cork)
+      env ||= EnvironmentManager.new(system_env, cork, danger_id)
       dm ||= Dangerfile.new(env, cork)
 
       ran_status = begin

--- a/spec/lib/danger/danger_core/environment_manager_spec.rb
+++ b/spec/lib/danger/danger_core/environment_manager_spec.rb
@@ -218,6 +218,22 @@ RSpec.describe Danger::EnvironmentManager, use: :ci_helper do
     end
   end
 
+  describe "#danger_id" do
+    it "returns the default identifier when none is provided" do
+      with_travis_setup_and_is_a_pull_request(request_source: :github) do |env|
+        env_manager = Danger::EnvironmentManager.new(env, testing_ui)
+        expect(env_manager.danger_id).to eq("danger")
+      end
+    end
+
+    it "returns the identifier user by danger" do
+      with_travis_setup_and_is_a_pull_request(request_source: :github) do |env|
+        env_manager = Danger::EnvironmentManager.new(env, testing_ui, "test_identifier")
+        expect(env_manager.danger_id).to eq("test_identifier")
+      end
+    end
+  end
+
   def git_repo_with_danger_branches_setup
     Dir.mktmpdir do |dir|
       Dir.chdir dir do


### PR DESCRIPTION
This PR addresses issue #1141 by exposing the value of `danger_id` via `EnvironmentManager`.

To access the value from inside a `Dangerfile` you can use `danger.env.danger_id`.

2 x unit tests have also been added to ensure the value passed is being set, and when none is provided that the default `danger` is used.